### PR TITLE
pAIs can now rescan their owner directly from the health scanner menu, without needing to return to the Medical Supplement menu to scan again.

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -468,8 +468,7 @@
 		dat += text("<BR>\n<A href='?src=\ref[];software=medicalsupplement;sub=0'>Back</A><BR>", src)
 	if(subscreen == 2)
 		dat += {"<h3>Medical Analysis Suite</h3><br>
-				 <h4>Host Bioscan</h4><br>
-				"}
+				 <h4>Host Bioscan</h4>"}
 		var/mob/living/M = loc
 		if(!istype(M, /mob/living))
 			while (!istype(M, /mob/living))
@@ -479,6 +478,7 @@
 					dat += "<a href='byond://?src=\ref[src];software=medicalsupplement;sub=0'>Return to Records</a><br>"
 					subscreen = 0
 					return dat
+				dat += "<a href='byond://?src=\ref[src];software=medicalsupplement;sub=2'>Update Scan</a><br>"
 				dat += healthanalyze(M, src, TRUE)
 		dat += "<br/><a href='byond://?src=\ref[src];software=medicalsupplement;sub=0'>Return to Records</a><br>"
 	return dat


### PR DESCRIPTION
## What this does
What it says on the tin.
## Why it's good
Quality of Life. Makes monitoring your owner's health less tedious.
[tested]
:cl:
 * rscadd: pAIs can now rescan their owner's health directly from the health scanner menu.